### PR TITLE
refactor: theme handling to use custom Rgb type

### DIFF
--- a/asg/src/asciicast.rs
+++ b/asg/src/asciicast.rs
@@ -1,8 +1,11 @@
+use std::collections::HashMap;
+use std::io::BufRead;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::io::BufRead;
+
+use crate::theme::Theme;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Header {
@@ -30,23 +33,6 @@ pub struct Header {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme: Option<Theme>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Theme {
-    pub fg: String,
-    pub bg: String,
-    pub palette: String,
-}
-
-impl Default for Theme {
-    fn default() -> Self {
-        Self {
-            fg: "#cccccc".to_string(),
-            bg: "#000000".to_string(),
-            palette: "#000000:#cd0000:#00cd00:#cdcd00:#0000ee:#cd00cd:#00cdcd:#e5e5e5:#7f7f7f:#ff0000:#00ff00:#ffff00:#5c5cff:#ff00ff:#00ffff:#ffffff".to_string(),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/asg/src/input.rs
+++ b/asg/src/input.rs
@@ -1,7 +1,8 @@
-use anyhow::{Context, Result};
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
+
+use anyhow::{Context, Result};
 
 pub enum InputSource {
     File(String),

--- a/asg/src/renderer.rs
+++ b/asg/src/renderer.rs
@@ -1,10 +1,11 @@
-use crate::terminal::Frame;
-use crate::theme::Theme;
 use anyhow::Result;
 use svg::Document;
 use svg::node::element::{
     Animate, Circle, Definitions, Group, Rectangle, Style, Text as TextElement,
 };
+
+use crate::terminal::Frame;
+use crate::theme::Theme;
 
 pub struct SvgRenderer {
     cols: usize,
@@ -150,9 +151,9 @@ impl SvgRenderer {
         // Basic styles
         css.push_str(&format!(
             r#"
-text {{ 
-    white-space: pre; 
-    font-family: monospace; 
+text {{
+    white-space: pre;
+    font-family: monospace;
     font-size: {}px;
 }}
 .frame {{ opacity: 0; }}


### PR DESCRIPTION
Refer to the Rgb implementation from https://github.com/teloxide/teloxide/blob/b9db5476845f080c51b56abad6645abe8359d495/crates/teloxide-core/src/types/rgb.rs